### PR TITLE
Add recommended API headers for Travis CI

### DIFF
--- a/app/models/status/travis.rb
+++ b/app/models/status/travis.rb
@@ -19,6 +19,10 @@ class Status::Travis < Status::Base
     end
 
     def api_result
-      JSON.parse(HTTP.get(api_endpoint))["last_build_status"]
+      JSON.parse(HTTP.headers(headers).get(api_endpoint))["last_build_status"]
+    end
+
+    def headers
+      { "User-Agent" => "Dasherize/1.0.0", accept: "application/vnd.travis-ci.2+json" }
     end
 end

--- a/spec/models/status/travis_spec.rb
+++ b/spec/models/status/travis_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Status::Travis do
     let(:travis) { Status::Travis.new("jollygoodcode/dasherize") }
 
     before do
-      allow(HTTP).to receive(:get)
+      allow(HTTP).to receive(:headers) { spy }
       allow(JSON).to receive(:parse) { Hash("last_build_status" => api_result) }
     end
 

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -30,7 +30,7 @@ module APIHelper
     stub_request(
       :get, "https://api.travis-ci.org/repos/sinatra/sinatra.json?branch=master"
     ).with(
-      headers: { "User-Agent" => "http.rb/0.9.8" }
+      headers: { "User-Agent" => "Dasherize/1.0.0", "Accept" => "application/vnd.travis-ci.2+json" }
     ).to_return(
       status: 200, body: IO.read("spec/fixtures/travis/sinatra.json"),
       headers: { "Content-Type" => "application/json" }
@@ -39,7 +39,7 @@ module APIHelper
     stub_request(
       :get, "https://api.travis-ci.org/repos/jollygoodcode/twemoji.json?branch=master"
     ).with(
-      headers: { "User-Agent" => "http.rb/0.9.8" }
+      headers: { "User-Agent" => "Dasherize/1.0.0", "Accept"=>"application/vnd.travis-ci.2+json" }
     ).to_return(
       status: 200, body: IO.read("spec/fixtures/travis/twemoji.json"),
       headers: { "Content-Type" => "application/json" }
@@ -48,7 +48,7 @@ module APIHelper
     stub_request(
       :get, "https://api.travis-ci.org/repos/winston/google_visualr.json?branch=master"
     ).with(
-      headers: { "User-Agent" => "http.rb/0.9.8" }
+      headers: { "User-Agent" => "Dasherize/1.0.0", "Accept" => "application/vnd.travis-ci.2+json" }
     ).to_return(
       status: 200, body: IO.read("spec/fixtures/travis/google_visualr.json"),
       headers: { "Content-Type" => "application/json" }


### PR DESCRIPTION
http://docs.travis-ci.com/api/?http#making-requests

> Always set the User-Agent header. This header is not required right now, but will be in the near future. Assuming your client is called “My Client”, and it’s current version is 1.0.0, a good value would be MyClient/1.0.0. For our command line client running on OS X 10.9 on Ruby 2.1.1, it might look like this: Travis/1.6.8 (Mac OS X 10.9.2 like Darwin; Ruby 2.1.1; RubyGems 2.0.14) Faraday/0.8.9 Typhoeus/0.6.7.
> Always set the Accept header to application/vnd.travis-ci.2+json.
