### PR TITLE
Ask less OAuth permissions

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -232,7 +232,7 @@ Devise.setup do |config|
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
-  config.omniauth :github, ENV['GITHUB_CLIENT_ID'], ENV['GITHUB_CLIENT_SECRET'], scope: 'user,repo'
+  config.omniauth :github, ENV["GITHUB_CLIENT_ID"], ENV["GITHUB_CLIENT_SECRET"], scope: "user:email,repo"
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/spec/models/oauth_account_spec.rb
+++ b/spec/models/oauth_account_spec.rb
@@ -5,34 +5,53 @@ RSpec.describe OauthAccount do
     it { is_expected.to belong_to(:user) }
   end
 
-  describe "#from_omniauth" do
-    let(:omniauth_json) do
-      OmniAuth::AuthHash.new JSON.parse(IO.read("spec/fixtures/omniauth.json"))
-    end
+  let(:omniauth_json) { OmniAuth::AuthHash.new JSON.parse(IO.read("spec/fixtures/omniauth.json")) }
+  let(:oauth_account) { OauthAccount.from_omniauth(omniauth_json) }
 
+  describe ".from_omniauth" do
     it "should create OauthAccount + User" do
-      oauth_account = OauthAccount.from_omniauth(omniauth_json)
-
       expect(oauth_account).to be_kind_of(OauthAccount)
       expect(oauth_account).to be_persisted
     end
 
     it "should be associated with a user" do
-      user = OauthAccount.from_omniauth(omniauth_json).user
+      user = oauth_account.user
 
       expect(user).to be_kind_of(User)
       expect(user).to be_persisted
     end
 
     it "should retrieve existing OauthAccount and User" do
-      OauthAccount.from_omniauth(omniauth_json)
+      oauth_account
 
       expect {
-        OauthAccount.from_omniauth(omniauth_json)
+        oauth_account
       }.not_to change {
         OauthAccount.count
         User.count
       }
+    end
+  end
+
+  describe "#oauth_token=" do
+    it "encrypts" do
+      cryptor = double
+      expect(ActiveSupport::MessageEncryptor).to receive(:new).and_return(cryptor)
+
+      expect(cryptor).to receive(:encrypt_and_sign)
+
+      oauth_account
+    end
+  end
+
+  describe "#oauth_token" do
+    it "decrypts" do
+      cryptor = double
+      expect(ActiveSupport::MessageEncryptor).to receive(:new).and_return(cryptor)
+
+      expect(cryptor).to receive(:encrypt_and_sign)
+
+      oauth_account.oauth_token
     end
   end
 end


### PR DESCRIPTION
This pull request:
- Changes OAuth scope to `user:email`
- Encrypts token in database

Note: need to migrate all current users' oauth token. :railway_car: 
## 

[GitHub API V3 OAuth Scope Doc](https://developer.github.com/v3/oauth/#scopes)
