### PR TITLE
Feature/link to ci

### DIFF
--- a/app/assets/stylesheets/application/projects.scss
+++ b/app/assets/stylesheets/application/projects.scss
@@ -56,6 +56,15 @@
 
     font-size: 0.65rem;
     font-style: italic;
+
+    a,
+    a:visited {
+      color: white;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
 
   .card-content {

--- a/app/models/project_decorator.rb
+++ b/app/models/project_decorator.rb
@@ -34,7 +34,11 @@ class ProjectDecorator < SimpleDelegator
   end
 
   def status
-    @_status
+    @_ci.status
+  end
+
+  def status_url
+    @_ci.url
   end
 
   private
@@ -56,16 +60,16 @@ class ProjectDecorator < SimpleDelegator
     end
 
     def init_ci
-      @_status =
+      @_ci =
         case ci_type
           when "travis"
-            Status::Travis.new(repo_name, travis_token).status
+            Status::Travis.new(repo_name, travis_token)
           when "codeship"
-            Status::Codeship.new(repo_name, codeship_uuid).status
+            Status::Codeship.new(repo_name, codeship_uuid)
           when "circleci"
-            Status::Circleci.new(repo_name, circleci_token).status
+            Status::Circleci.new(repo_name, circleci_token)
           else
-            :unavailable
+            Status::Null.new
         end
     end
 end

--- a/app/models/status/circleci.rb
+++ b/app/models/status/circleci.rb
@@ -2,7 +2,7 @@ class Status::Circleci < Status::Base
   ENDPOINT = "https://circleci.com/api/v1/project".freeze
 
   def status
-    case api_result
+    case build_state
       when "fixed", "success"
         :passed
       when "retried", "canceled", "infrastructure_fail", "timedout", "failed", "no_tests"
@@ -12,21 +12,33 @@ class Status::Circleci < Status::Base
     end
   end
 
+  def url
+    build_url
+  end
+
   private
+
+    def api_result
+      JSON.parse(HTTP.headers(headers).get(api_endpoint)).first
+    end
+
+    def build_state
+      api_result["status"]
+    end
+
+    def build_url
+      api_result["build_url"]
+    end
 
     def api_endpoint
       if auth_token
-        "#{ENDPOINT}/#{repo_name}?circle-token=#{auth_token}"
+        "#{ENDPOINT}/#{repo_name}/tree/#{branch}?circle-token=#{auth_token}"
       else
-        "#{ENDPOINT}/#{repo_name}"
+        "#{ENDPOINT}/#{repo_name}/tree/#{branch}"
       end
     end
 
-    def api_result
-      response.find { |build| build["branch"] == branch }["status"]
-    end
-
-    def response
-      JSON.parse(HTTP.headers(accept: "application/json").get(api_endpoint))
+    def headers
+      { accept: "application/json" }
     end
 end

--- a/app/models/status/codeship.rb
+++ b/app/models/status/codeship.rb
@@ -1,6 +1,6 @@
 class Status::Codeship < Status::Base
   def status
-    case api_result
+    case build_state
       when :success
         :passed
       when :error, :projectnotfound, :branchnotfound, :ignored, :stopped, :infrastructure_failure
@@ -10,9 +10,17 @@ class Status::Codeship < Status::Base
     end
   end
 
+  def url
+    "https://codeship.com/projects"
+  end
+
   private
 
     def api_result
-      Codeship::Status.new(auth_token, branch: branch).status
+      Codeship::Status.new(auth_token, branch: branch)
+    end
+
+    def build_state
+      api_result.status
     end
 end

--- a/app/models/status/null.rb
+++ b/app/models/status/null.rb
@@ -1,6 +1,6 @@
 class Status::Null
   def status
-    :failed
+    :unavailable
   end
 
   def url

--- a/app/models/status/null.rb
+++ b/app/models/status/null.rb
@@ -1,0 +1,9 @@
+class Status::Null
+  def status
+    :failed
+  end
+
+  def url
+    ""
+  end
+end

--- a/app/models/status/travis.rb
+++ b/app/models/status/travis.rb
@@ -1,6 +1,8 @@
 class Status::Travis < Status::Base
+  ENDPOINT = "https://api.travis-ci.org/repos".freeze
+
   def status
-    case api_result
+    case build_state
       when "passed"
         :passed
       when "failed"
@@ -10,17 +12,29 @@ class Status::Travis < Status::Base
     end
   end
 
+  def url
+    "https://travis-ci.org/#{repo_name}/builds/#{build_id}"
+  end
+
   private
 
     def api_result
-      JSON.parse(HTTP.headers(headers).get(api_endpoint))["branch"]["state"]
+      JSON.parse(HTTP.headers(headers).get(api_endpoint))
+    end
+
+    def build_state
+      api_result["branch"]["state"]
+    end
+
+    def build_id
+      api_result["branch"]["id"]
     end
 
     def api_endpoint
       if auth_token.present?
-        "https://api.travis-ci.org/repos/#{repo_name}/branches/#{branch}.json&token=#{auth_token}"
+        "#{ENDPOINT}/#{repo_name}/branches/#{branch}.json&token=#{auth_token}"
       else
-        "https://api.travis-ci.org/repos/#{repo_name}/branches/#{branch}.json"
+        "#{ENDPOINT}/#{repo_name}/branches/#{branch}.json"
       end
     end
 

--- a/app/views/projects/_project.html.slim
+++ b/app/views/projects/_project.html.slim
@@ -21,7 +21,7 @@
           .number-title Issues
     .card-status.center class=status_class(project.status)
       .indeterminate
-      = status_text(project.status)
+      = link_to status_text(project.status), project.status_url, target: "_blank"
 
     .card-content
       h6 Pull Requests

--- a/spec/models/status/circleci_spec.rb
+++ b/spec/models/status/circleci_spec.rb
@@ -1,14 +1,14 @@
 RSpec.describe Status::Circleci do
-  let(:failure_messages) do
-    %w(retried canceled infrastructure_fail timedout failed no_tests)
-  end
-
-  let(:waiting_messages) do
-    %w(not_run running queued scheduled not_running)
-  end
-
   describe "#status" do
     let(:circleci) { Status::Circleci.new("mtchavez/circleci") }
+
+    let(:failure_messages) do
+      %w(retried canceled infrastructure_fail timedout failed no_tests)
+    end
+
+    let(:waiting_messages) do
+      %w(not_run running queued scheduled not_running)
+    end
 
     before do
       allow(HTTP).to receive(:headers) { spy }
@@ -38,5 +38,16 @@ RSpec.describe Status::Circleci do
         expect(circleci.status).to eq :waiting
       end
     end
+  end
+
+  describe "#url" do
+    let(:circleci) { Status::Circleci.new("mtchavez/circleci") }
+
+    before do
+      allow(HTTP).to receive(:headers) { spy }
+      allow(JSON).to receive(:parse) { [{ "branch" => "master", "build_url" => "https://circleci.com" }] }
+    end
+
+    it { expect(circleci.url).to eq "https://circleci.com" }
   end
 end

--- a/spec/models/status/codeship_spec.rb
+++ b/spec/models/status/codeship_spec.rb
@@ -1,14 +1,12 @@
 RSpec.describe Status::Codeship do
-  let(:failure_messages) do
-    %i(error projectnotfound branchnotfound ignored stopped infrastructure_failure)
-  end
-
   describe "#status" do
     let(:codeship) { Status::Codeship.new("jollygoodcode/dasherize") }
 
-    before do
-      allow(Codeship::Status).to receive(:new) { double(status: api_result) }
+    let(:failure_messages) do
+      %i(error projectnotfound branchnotfound ignored stopped infrastructure_failure)
     end
+
+    before { allow(Codeship::Status).to receive(:new) { double(status: api_result) } }
 
     context "API returns success" do
       let(:api_result) { :success }
@@ -33,5 +31,15 @@ RSpec.describe Status::Codeship do
         expect(codeship.status).to eq :waiting
       end
     end
+  end
+
+  # Codeship doesn't have an api that could easily return the build url
+  # If we have to implement this, we would first need to know the Codeship ID of the project
+  # which means storing another field in the database -> not something we want..
+  # Hence best effort for now is at least to link to Codeship
+  describe "#url" do
+    let(:codeship) { Status::Codeship.new("jollygoodcode/dasherize") }
+
+    it { expect(codeship.url).to eq "https://codeship.com/projects" }
   end
 end

--- a/spec/models/status/travis_spec.rb
+++ b/spec/models/status/travis_spec.rb
@@ -31,4 +31,18 @@ RSpec.describe Status::Travis do
       end
     end
   end
+
+  describe "#url" do
+    let(:repo)      { "jollygoodcode/dasherize" }
+    let(:build_id)  { "1234567890" }
+
+    let(:travis)    { Status::Travis.new(repo) }
+
+    before do
+      allow(HTTP).to receive(:headers) { spy }
+      allow(JSON).to receive(:parse) { Hash("branch" => { "id" => build_id }) }
+    end
+
+    it { expect(travis.url).to eq "https://travis-ci.org/#{repo}/builds/#{build_id}"}
+  end
 end


### PR DESCRIPTION
Links to CI's build, so that it's easy to inspect if build is passing or failing.

Works easily for Travis and CircleCI. Codeship however doesn't work unless we store the project id, hence best effort for now is to just redirect to the Codeship site.

Also refactored some code.

![screen shot 2015-10-08 at 4 25 37 pm](https://cloud.githubusercontent.com/assets/2112/10361255/59b79ed6-6dd9-11e5-9fa6-0b946034a7c4.png)

@JuanitoFatas :bow: 
