### PR TITLE
Introduce a `run!` method for Status::Base 

### DIFF
--- a/app/models/project_decorator.rb
+++ b/app/models/project_decorator.rb
@@ -63,11 +63,11 @@ class ProjectDecorator < SimpleDelegator
       @_ci =
         case ci_type
           when "travis"
-            Status::Travis.new(repo_name, travis_token)
+            Status::Travis.new(repo_name, travis_token).run!
           when "codeship"
-            Status::Codeship.new(repo_name, codeship_uuid)
+            Status::Codeship.new(repo_name, codeship_uuid).run!
           when "circleci"
-            Status::Circleci.new(repo_name, circleci_token)
+            Status::Circleci.new(repo_name, circleci_token).run!
           else
             Status::Null.new
         end

--- a/app/models/status/base.rb
+++ b/app/models/status/base.rb
@@ -1,6 +1,6 @@
 module Status
   class Base
-    attr_reader :repo_name, :auth_token
+    attr_reader :repo_name, :auth_token, :response
 
     def initialize(repo_name, auth_token=nil)
       @repo_name  = repo_name
@@ -9,6 +9,11 @@ module Status
 
     def branch
       "master"
+    end
+
+    def run!
+      @response ||= api_result
+      self
     end
   end
 end

--- a/app/models/status/circleci.rb
+++ b/app/models/status/circleci.rb
@@ -23,11 +23,11 @@ class Status::Circleci < Status::Base
     end
 
     def build_state
-      api_result["status"]
+      response["status"]
     end
 
     def build_url
-      api_result["build_url"]
+      response["build_url"]
     end
 
     def api_endpoint

--- a/app/models/status/codeship.rb
+++ b/app/models/status/codeship.rb
@@ -21,6 +21,6 @@ class Status::Codeship < Status::Base
     end
 
     def build_state
-      api_result.status
+      response.status
     end
 end

--- a/app/models/status/travis.rb
+++ b/app/models/status/travis.rb
@@ -23,11 +23,11 @@ class Status::Travis < Status::Base
     end
 
     def build_state
-      api_result["branch"]["state"]
+      response["branch"]["state"]
     end
 
     def build_id
-      api_result["branch"]["id"]
+      response["branch"]["id"]
     end
 
     def api_endpoint

--- a/spec/models/project_decorator_spec.rb
+++ b/spec/models/project_decorator_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe ProjectDecorator do
       let(:ci_type) { "travis" }
 
       it "returns API result from Status::Travis" do
-        expect(Status::Travis).to receive(:new) { double(status: :passed) }
+        expect(Status::Travis).to receive_message_chain(:new, :run!) { double(status: :passed) }
 
         subject.process_with
 
@@ -102,7 +102,7 @@ RSpec.describe ProjectDecorator do
       let(:ci_type) { "codeship" }
 
       it "returns API result from Status::Codeship" do
-        expect(Status::Codeship).to receive(:new) { double(status: :passed) }
+        expect(Status::Codeship).to receive_message_chain(:new, :run!) { double(status: :passed) }
 
         subject.process_with
 
@@ -114,7 +114,7 @@ RSpec.describe ProjectDecorator do
       let(:ci_type) { "circleci" }
 
       it "returns API result from Status::Circleci" do
-        expect(Status::Circleci).to receive(:new) { double(status: :passed) }
+        expect(Status::Circleci).to receive_message_chain(:new, :run!) { double(status: :passed) }
 
         subject.process_with
 

--- a/spec/models/status/circleci_spec.rb
+++ b/spec/models/status/circleci_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Status::Circleci do
   describe "#status" do
-    let(:circleci) { Status::Circleci.new("mtchavez/circleci") }
+    let(:circleci) { Status::Circleci.new("mtchavez/circleci").run! }
 
     let(:failure_messages) do
       %w(retried canceled infrastructure_fail timedout failed no_tests)
@@ -41,7 +41,7 @@ RSpec.describe Status::Circleci do
   end
 
   describe "#url" do
-    let(:circleci) { Status::Circleci.new("mtchavez/circleci") }
+    let(:circleci) { Status::Circleci.new("mtchavez/circleci").run! }
 
     before do
       allow(HTTP).to receive(:headers) { spy }

--- a/spec/models/status/codeship_spec.rb
+++ b/spec/models/status/codeship_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Status::Codeship do
   describe "#status" do
-    let(:codeship) { Status::Codeship.new("jollygoodcode/dasherize") }
+    let(:codeship) { Status::Codeship.new("jollygoodcode/dasherize").run! }
 
     let(:failure_messages) do
       %i(error projectnotfound branchnotfound ignored stopped infrastructure_failure)
@@ -38,7 +38,7 @@ RSpec.describe Status::Codeship do
   # which means storing another field in the database -> not something we want..
   # Hence best effort for now is at least to link to Codeship
   describe "#url" do
-    let(:codeship) { Status::Codeship.new("jollygoodcode/dasherize") }
+    let(:codeship) { Status::Codeship.new("jollygoodcode/dasherize").run! }
 
     it { expect(codeship.url).to eq "https://codeship.com/projects" }
   end

--- a/spec/models/status/travis_spec.rb
+++ b/spec/models/status/travis_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Status::Travis do
   describe "#status" do
-    let(:travis) { Status::Travis.new("jollygoodcode/dasherize") }
+    let(:travis) { Status::Travis.new("jollygoodcode/dasherize").run! }
 
     before do
       allow(HTTP).to receive(:headers) { spy }
@@ -36,7 +36,7 @@ RSpec.describe Status::Travis do
     let(:repo)      { "jollygoodcode/dasherize" }
     let(:build_id)  { "1234567890" }
 
-    let(:travis)    { Status::Travis.new(repo) }
+    let(:travis)    { Status::Travis.new(repo).run! }
 
     before do
       allow(HTTP).to receive(:headers) { spy }


### PR DESCRIPTION
This method returns `self` and makes a request for the api endpoint and memoizes the result.

In this way, results can be cached properly.
