### PR TITLE
Revert "Patch/Don't save user image and email in OauthAccount"

### DIFF
--- a/app/models/oauth_account.rb
+++ b/app/models/oauth_account.rb
@@ -6,11 +6,14 @@ class OauthAccount < ActiveRecord::Base
       account.provider         = auth.provider
       account.uid              = auth.uid
       account.name             = auth.info.name
+      account.email            = auth.info.email
+      account.image_url        = auth.info.image
       account.oauth_token      = auth.credentials.token
 
       (account.user || account.build_user).tap do |user|
         user.attributes = {
-          name: account.name || auth.info.nickname || auth.extra.raw_info.username
+          name: account.name,
+          email: account.email || auth.info.nickname || auth.extra.raw_info.username
         }
         user.confirm
         user.save(validate: false)

--- a/db/migrate/20151014162444_add_back_columns_to_oauth_accounts.rb
+++ b/db/migrate/20151014162444_add_back_columns_to_oauth_accounts.rb
@@ -1,0 +1,8 @@
+class AddBackColumnsToOauthAccounts < ActiveRecord::Migration
+  def change
+    add_column :oauth_accounts, :email, :string
+    add_column :oauth_accounts, :image_url, :string
+    add_column :oauth_accounts, :oauth_secret, :string
+    add_column :oauth_accounts, :oauth_expires_at, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151009034510) do
+ActiveRecord::Schema.define(version: 20151014162444) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,10 @@ ActiveRecord::Schema.define(version: 20151009034510) do
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "email"
+    t.string   "image_url"
+    t.string   "oauth_secret"
+    t.string   "oauth_expires_at"
   end
 
   add_index "oauth_accounts", ["user_id"], name: "index_oauth_accounts_on_user_id", using: :btree

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe OmniauthCallbacksController do
         double(
           :user,
           name: "Audrey",
+          email: "audrey@example.com",
           oauth_account: double(oauth_token: "token")
         )
       end
@@ -37,7 +38,7 @@ RSpec.describe OmniauthCallbacksController do
         do_request
 
         expect(User.count).to eq 1
-        expect(User.last).to have_attributes(name: "Audrey")
+        expect(User.last).to have_attributes(name: "Audrey", email: "audrey@example.com")
       end
     end
   end

--- a/spec/support/oauth_helper.rb
+++ b/spec/support/oauth_helper.rb
@@ -16,7 +16,7 @@ module OAuthHelper
   def stub_oauth(user)
     OmniAuth.config.add_mock(
       :github,
-      info: { name: user.name },
+      info: { name: user.name, email: user.email },
       credentials: { token: user.oauth_account.oauth_token }
     )
   end


### PR DESCRIPTION
Reverts jollygoodcode/dasherize#26

Tried to store less but devise use email as unique index so we need it. Not removing devise because people may found devise useful to extend it forward.
